### PR TITLE
Bugfix/linux container build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,6 @@ matrix:
         - UNICODE_WIDTH=16
 
     - os: linux
-      env: VERSION=3.4
-
-    - os: linux
       env: VERSION=3.5
 
     - os: linux

--- a/travis/build_linux_wheel.sh
+++ b/travis/build_linux_wheel.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 UNICODE_WIDTH="${UNICODE_WIDTH:-32}"
 
 # Install cmake
-wget --no-check-certificate http://www.cmake.org/files/v3.2/cmake-3.2.0-Linux-x86_64.sh
+curl -L https://www.cmake.org/files/v3.2/cmake-3.2.0-Linux-x86_64.sh --output cmake-3.2.0-Linux-x86_64.sh
 sh cmake-3.2.0-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
 
 # Install zlib

--- a/travis/build_linux_wheel.sh
+++ b/travis/build_linux_wheel.sh
@@ -12,6 +12,9 @@ sh cmake-3.2.0-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
 # Install zlib
 yum install -y zlib-devel
 
+# Install LibLZMA
+yum install -y xz-devel
+
 # taken from https://github.com/matthew-brett/manylinux-builds/blob/master/common_vars.sh
 function lex_ver {
     # Echoes dot-separated version string padded with zeros


### PR DESCRIPTION
Linux builds can't even get out of the gate, even with the ICU dependency fix, because the build is so old, the underlying container representing `latest` has moved: this is strictly necessary, because, without an explicit tag, there is absolutely no way to tell with layer `latest` was pointing to when this was last building cleanly.