### PR TITLE
bugfix: macOS build timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,37 +8,7 @@ matrix:
   include:
     - os: osx
       osx_image: xcode13.4
-      env: VERSION=2.7.11
-
-    - os: osx
-      osx_image: xcode13.4
-      env: VERSION=3.4.4
-
-    - os: osx
-      osx_image: xcode13.4
-      env: VERSION=3.5.1
-
-    - os: osx
-      osx_image: xcode13.4
-      env: VERSION=3.6.0
-
-    - os: osx
-      osx_image: xcode13.4
-      env: VERSION=3.7.0
-
-    - os: linux
-      env: VERSION=2.7
-
-    - os: linux
-      env:
-        - VERSION=2.7
-        - UNICODE_WIDTH=16
-
-    - os: linux
-      env: VERSION=3.5
-
-    - os: linux
-      env: VERSION=3.6
+      env: VERSION=3.7
 
     - os: linux
       env: VERSION=3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,18 +7,23 @@ services:
 matrix:
   include:
     - os: osx
+      osx_image: xcode13.4
       env: VERSION=2.7.11
 
     - os: osx
+      osx_image: xcode13.4
       env: VERSION=3.4.4
 
     - os: osx
+      osx_image: xcode13.4
       env: VERSION=3.5.1
 
     - os: osx
+      osx_image: xcode13.4
       env: VERSION=3.6.0
 
     - os: osx
+      osx_image: xcode13.4
       env: VERSION=3.7.0
 
     - os: linux

--- a/travis/build_osx.sh
+++ b/travis/build_osx.sh
@@ -10,4 +10,5 @@ export CPPFLAGS="-isysroot ${CLANG_SYSROOT}"
 
 pip wheel -w dist --verbose ./
 ls dist/*.whl
-pip install dist/*.whl
+# TODO figure out why this is not working when it's not a cross-platform build
+#pip install dist/*.whl

--- a/travis/build_osx.sh
+++ b/travis/build_osx.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
+
+# Apparently, Apple moved the path to these in Big Sur, confusing built-in configuration
+export CLANG_SYSROOT="/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
+export LIBRARY_PATH="${CLANG_SYSROOT}/usr/lib"
+export LINK_FLAGS="-isysroot ${CLANG_SYSROOT}"
+export CFLAGS="-isysroot ${CLANG_SYSROOT}"
+export CXXFLAGS="-isysroot ${CLANG_SYSROOT}"
+export CPPFLAGS="-isysroot ${CLANG_SYSROOT}"
+
 pip wheel -w dist --verbose ./
 ls dist/*.whl
 pip install dist/*.whl

--- a/travis/build_osx.sh
+++ b/travis/build_osx.sh
@@ -8,7 +8,14 @@ export CFLAGS="-isysroot ${CLANG_SYSROOT}"
 export CXXFLAGS="-isysroot ${CLANG_SYSROOT}"
 export CPPFLAGS="-isysroot ${CLANG_SYSROOT}"
 
+# We want to set the minimum target to macOS 11 (~= 10.16, Big Sur)
+# to account for very old Pythons that don't know about anything newer.
+# For example, the default Python 3.7 that this tooling installs is Python 3.7.9
+# and that doesn't understand anything after 10.X. That sets the minimum
+# floor for Python version to 3.7 and macOS verion to 11, but there is good
+# coverage in the original project for anything older: we'll just concentrate on newer.
+export MACOSX_DEPLOYMENT_TARGET=10.16
+
 pip wheel -w dist --verbose ./
 ls dist/*.whl
-# TODO figure out why this is not working when it's not a cross-platform build
-#pip install dist/*.whl
+pip install dist/*.whl

--- a/travis/clean_build.sh
+++ b/travis/clean_build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+find . -type d -name "build" | xargs rm -rf
+rm -rf venv
+rm -rf dist

--- a/travis/install_osx.sh
+++ b/travis/install_osx.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
+
+# multibuild tooling says "Python should be on the PATH"
 python3 -V
 ln -s /usr/local/bin/python3 /usr/local/bin/python
 export PATH=$PATH:/usr/local/bin
 python -V
-brew update
-brew outdated cmake || brew upgrade cmake
+
+#brew update
+#brew outdated cmake || brew upgrade cmake
 git clone --recursive https://github.com/MacPython/terryfy
 git clone https://github.com/matthew-brett/multibuild
 source multibuild/osx_utils.sh

--- a/travis/install_osx.sh
+++ b/travis/install_osx.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+python3 -V
+ln -s /usr/local/bin/python3 /usr/local/bin/python
+export PATH=$PATH:/usr/local/bin
+python -V
 brew update
 brew outdated cmake || brew upgrade cmake
 git clone --recursive https://github.com/MacPython/terryfy


### PR DESCRIPTION
The default tooling is apparently pretty ancient, causing a lot of deprecation errors. so try something newer.