### PR TITLE
Update to pybind11 v2.3.0 which fixes 3.7-related GIL mismanagement

### DIFF
--- a/include/metapy_identifiers.h
+++ b/include/metapy_identifiers.h
@@ -24,7 +24,7 @@ struct identifier_caster
     using underlying_type = typename Type::underlying_type;
     using type_conv = make_caster<underlying_type>;
 
-    PYBIND11_TYPE_CASTER(Type, _("id[") + type_conv::name() + _("]"));
+    PYBIND11_TYPE_CASTER(Type, _("id[") + type_conv::name + _("]"));
 
     bool load(handle src, bool convert)
     {

--- a/include/metapy_index.h
+++ b/include/metapy_index.h
@@ -56,10 +56,7 @@ struct type_caster<meta::index::search_result>
         return result.release();
     }
 
-    static PYBIND11_DESCR name()
-    {
-        return type_descr(_("SearchResult"));
-    }
+    static constexpr auto name = _("SearchResult");
 
     static handle cast(const meta::index::search_result* sr,
                        return_value_policy policy, handle parent)

--- a/include/metapy_probe_map.h
+++ b/include/metapy_probe_map.h
@@ -62,8 +62,8 @@ struct probe_map_caster
         return d.release();
     }
 
-    PYBIND11_TYPE_CASTER(type, _("dict<") + key_conv::name() + _(", ")
-                                   + value_conv::name() + _(">"));
+    PYBIND11_TYPE_CASTER(type, _("dict<") + key_conv::name + _(", ")
+                                   + value_conv::name + _(">"));
 };
 
 template <class Key, class Value, class ProbingStrategy, class Hash,

--- a/src/metapy_embeddings.cpp
+++ b/src/metapy_embeddings.cpp
@@ -41,7 +41,7 @@ void metapy_bind_embeddings(py::module& m)
                     query,
                 std::size_t k) {
                  util::array_view<const double> avquery{query.data(),
-                                                        query.size()};
+                                                        static_cast<std::size_t>(query.size())};
                  auto scores = self.top_k(avquery, k);
 
                  std::vector<py::tuple> result;


### PR DESCRIPTION
The root cause of this defect, which exists on Python 3.7 in the original project, and also on all subsequent versions in our fork, was [this pybind11 defect](https://github.com/pybind/pybind11/issues/1473) related to the move from [TLS to TSS in Python 3.7](https://peps.python.org/pep-0539/). Because the symptoms of the misbehaving software looked very much like GIL mismanagement when examining the system calls (stuck in a tight polling loop, presumable in deadlock), it was easy to make the connection with the above defect and try the proposed solution, which was to upgrade to `pybind11` version 2.3 or higher. Another hint of where to look came from a other projects reporting similar issues on Github, and pointing to the root cause issue (e.g.: [pytorch #11419](https://github.com/pytorch/pytorch/issues/11419)).