### PR TITLE
Add Docker support

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: arm64
+          platforms: arm64,amd64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to Docker Hub
@@ -40,6 +40,6 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/arm64
+          platforms: linux/arm64,linux/amd64
           push: true
           tags: josecols/metapy:0.2.13

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: arm64,amd64
+          platforms: arm64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to Docker Hub
@@ -40,6 +40,6 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           push: true
           tags: josecols/metapy:0.2.13

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,45 @@
+name: Docker Image CI
+
+concurrency:
+  group: docker-image-ci
+  cancel-in-progress: true
+
+on:
+  push:
+  #    branches:
+  #      - master
+  workflow_run:
+    workflows: [ "Docker Base Image CI" ]
+    types:
+      - completed
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64,amd64
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: josecols/metapy:0.2.13

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ doc/
 *.o
 *.class
 .*
+!.github/
 data/ceeaus
 data/breast-cancer
 data/housing

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "deps/meta"]
 	path = deps/meta
-	url = https://github.com/meta-toolkit/meta.git
+	url = https://github.com/dmcguire81/meta
 [submodule "deps/pybind11"]
 	path = deps/pybind11
 	url = https://github.com/pybind/pybind11

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
     python3-pip
 
 WORKDIR /metapy
-RUN git submodule update --init --recursive
+RUN git submodule update --init --recursive -- deps/pybind11
 RUN mkdir build
 
 WORKDIR /metapy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM josecols/meta:3.0.2
+
+ENV LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2
+
+COPY . /metapy
+
+RUN apt-get update && apt-get install -y \
+    python-is-python3 \
+    python3-dev \
+    python3-pip
+
+WORKDIR /metapy
+RUN git submodule update --init --recursive
+RUN mkdir build
+
+WORKDIR /metapy
+RUN sed -i 's:add_subdirectory(deps/meta EXCLUDE_FROM_ALL):find_package(MeTA 3.0.2 REQUIRED):g' CMakeLists.txt
+RUN pip install .
+
+WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM josecols/meta:3.0.2
+FROM josecols/meta:3.0.2 as base
 
+ARG TARGETARCH
 COPY . /metapy
 
 RUN apt-get update && apt-get install -y \
@@ -8,10 +9,17 @@ RUN apt-get update && apt-get install -y \
     python3-pip
 
 WORKDIR /metapy
-ENV LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2
 RUN git submodule update --init --recursive -- deps/pybind11
 RUN mkdir build
 RUN sed -i 's:add_subdirectory(deps/meta EXCLUDE_FROM_ALL):find_package(MeTA 3.0.2 REQUIRED):g' CMakeLists.txt
 RUN pip install .
+
+FROM base AS branch-arm64
+ENV LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2
+
+FROM base AS branch-amd64
+ENV LD_PRELOAD=/lib/x86_64-linux-gnu/libjemalloc.so.2
+
+FROM branch-${TARGETARCH} AS final
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM josecols/meta:3.0.2
 
-ENV LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2
-
 COPY . /metapy
 
 RUN apt-get update && apt-get install -y \
@@ -10,10 +8,9 @@ RUN apt-get update && apt-get install -y \
     python3-pip
 
 WORKDIR /metapy
+ENV LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2
 RUN git submodule update --init --recursive -- deps/pybind11
 RUN mkdir build
-
-WORKDIR /metapy
 RUN sed -i 's:add_subdirectory(deps/meta EXCLUDE_FROM_ALL):find_package(MeTA 3.0.2 REQUIRED):g' CMakeLists.txt
 RUN pip install .
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@ to make it seamless to use MeTA's components within any Python application
 This project is made possible by the excellent [pybind11][pybind11]
 library.
 
+## Getting Started (Docker)
+
+A [Docker](https://www.docker.com/) image with a pre-built version of MeTA and `metapy` is available on [Docker Hub](https://hub.docker.com/r/josecols/metapy/tags)
+
+```bash
+docker pull josecols/metapy:0.2.13
+```
+
+This Docker image simplifies the execution of Python scripts that rely on `metapy`. For example, to run CS 410 Text Information Systems MP assignments, simply run the following command at the MP directory's root.
+
+```bash
+docker run -it --rm --name metapy --mount type=bind,source=$(pwd),target=/app --entrypoint bash josecols/metapy:0.2.13
+```
+
+Then, you can run the Python scripts as usual, e.g., `python mp1.py`. Keep in mind that any changes to files in your current directory that occur within the container will be automatically reflected on your host file system.
+
 ## Getting Started (the easy way)
 
 ```bash


### PR DESCRIPTION
This PR includes a Dockerfile that extends the MeTA Docker image to install metapy. Users can use the Dockerfile or the Docker image built from it to run Python programs that require metapy.